### PR TITLE
  Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trialr
-Version: 0.1.5
-Date: 2020-10-14
+Version: 0.1.5.9001
+Date: 2023-10-15
 Title: Clinical Trial Designs in 'rstan'
 Description: A collection of clinical trial designs and methods, implemented in 
     'rstan' and R, including: the Continual Reassessment Method by O'Quigley et 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Depends:
   R (>= 3.5.0), 
   methods,Rcpp (>= 1.0.1)
 Imports:
-  rstan (>= 2.18.2), 
+  rstan (>= 2.26.0), 
   rstantools (>= 1.5.1),
   rlang (>= 0.4.5),
   dplyr,
@@ -45,8 +45,8 @@ Imports:
   binom,
   MASS
 LinkingTo:
-  StanHeaders (>= 2.18.1), 
-  rstan (>= 2.18.2), 
+  StanHeaders (>= 2.26.0), 
+  rstan (>= 2.26.0), 
   BH (>= 1.69.0-1), 
   Rcpp (>= 1.0.1), 
   RcppEigen (>= 0.3.3.5.0), 

--- a/R/EffTox.R
+++ b/R/EffTox.R
@@ -85,7 +85,7 @@ summary.efftox_fit <- function(object, ...) {
 #'
 #' @description This function allows trialr to use tidybayes functions.
 #'
-#' @param efftox_fit Object of class \code{\link{efftox_fit}}
+#' @param x Object of class \code{\link{efftox_fit}}
 #' @param ... Extra variables that are passed onwards.
 #'
 #' @return Object of class \code{\link[coda]{mcmc.list}}
@@ -94,7 +94,7 @@ summary.efftox_fit <- function(object, ...) {
 #' @importFrom coda as.mcmc.list
 #' @importFrom rstan As.mcmc.list
 #' @export
-as.mcmc.list.efftox_fit <- function(efftox_fit, ...) {
-  As.mcmc.list(efftox_fit$fit, ...)
+as.mcmc.list.efftox_fit <- function(x, ...) {
+  As.mcmc.list(x$fit, ...)
 }
 

--- a/R/crm_fit.R
+++ b/R/crm_fit.R
@@ -170,7 +170,7 @@ summary.crm_fit <- function(object, ...) {
 #'
 #' @description This function allows trialr to use tidybayes functions.
 #'
-#' @param crm_fit Object of class \code{\link{crm_fit}}
+#' @param x Object of class \code{\link{crm_fit}}
 #' @param ... Extra variables that are passed onwards.
 #'
 #' @return Object of class \code{\link[coda]{mcmc.list}}
@@ -180,10 +180,10 @@ summary.crm_fit <- function(object, ...) {
 #' @importFrom coda mcmc
 #' @importFrom rstan As.mcmc.list
 #' @export
-as.mcmc.list.crm_fit <- function(crm_fit, ...) {
-  if(is.null(crm_fit$fit)) {
-    as.mcmc.list(mcmc(crm_fit$samples))
+as.mcmc.list.crm_fit <- function(x, ...) {
+  if(is.null(x$fit)) {
+    as.mcmc.list(mcmc(x$samples))
   } else {
-    As.mcmc.list(crm_fit$fit, ...)
+    As.mcmc.list(x$fit, ...)
   }
 }

--- a/Scratch/Control.R
+++ b/Scratch/Control.R
@@ -1,0 +1,5 @@
+
+# To reinstall
+# devtools::install(build = TRUE)
+devtools::install(build = TRUE, args = "--preclean")
+devtools::install(build = FALSE) # Skip recompilation

--- a/inst/stan/AugBin2T1A.stan
+++ b/inst/stan/AugBin2T1A.stan
@@ -6,8 +6,8 @@ data {
   vector[N] z1;  // Tumour sizes at assessment 1
   vector[N] z2;  // Tumour sizes at assessment 2
 
-  int<lower=0, upper=1> d1[N]; // Non-shrinkage failures at assessment 1
-  int<lower=0, upper=1> d2[N]; // Non-shrinkage failures at assessment 2
+  array[N] int<lower=0, upper=1> d1; // Non-shrinkage failures at assessment 1
+  array[N] int<lower=0, upper=1> d2; // Non-shrinkage failures at assessment 2
 
   // Hyperparameters
   // Tumour size model
@@ -33,7 +33,7 @@ data {
 }
 
 transformed data {
-  vector[2] y[N]; // y, log tumour size ratios, has N rows and 2 columns
+  array[N] vector[2] y; // y, log tumour size ratios, has N rows and 2 columns
   for(i in 1:N) {
     y[i][1] = log(z1[i] / z0[i]);
     y[i][2] = log(z2[i] / z0[i]);
@@ -53,9 +53,9 @@ parameters {
 }
 
 transformed parameters {
-  vector[2] Mu[N];
+  array[N] vector[2] Mu;
   cov_matrix[2] Sigma;
-  vector[2] ProbD[N];
+  array[N] vector[2] ProbD;
 
   for(i in 1:N) {
     Mu[i][1] = alpha + gamma * z0[i];

--- a/inst/stan/BebopInPeps2.stan
+++ b/inst/stan/BebopInPeps2.stan
@@ -4,7 +4,7 @@
 // by Thall and Cook.
 
 functions {
-  real log_joint_pdf(int J, int[] eff, int[] tox, int[] x1, int[] x2, int[] x3,
+  real log_joint_pdf(int J, array[] int eff, array[] int tox, array[] int x1, array[] int x2, array[] int x3,
                      real alpha, real beta, real gamma, real zeta, real lambda,
                      real psi) {
     real p;
@@ -28,11 +28,11 @@ functions {
 
 data {
   int<lower=0> J; // number of obs
-  int<lower=0, upper=1> eff[J]; // event one
-  int<lower=0, upper=1> tox[J]; // event two
-  int<lower=0, upper=1> x1[J];  // x1=1 if pre-treated, else 0
-  int<lower=0, upper=1> x2[J];  // x2=1 if PD-L1 is low
-  int<lower=0, upper=1> x3[J];  // x3=1 if PD-L1 is medium
+  array[J] int<lower=0, upper=1> eff; // event one
+  array[J] int<lower=0, upper=1> tox; // event two
+  array[J] int<lower=0, upper=1> x1;  // x1=1 if pre-treated, else 0
+  array[J] int<lower=0, upper=1> x2;  // x2=1 if PD-L1 is low
+  array[J] int<lower=0, upper=1> x3;  // x3=1 if PD-L1 is medium
                                 // Implicityly, x2=0 & x3=0 if PD-L1 is high
 
   // Hyperparameters
@@ -60,8 +60,8 @@ parameters {
 }
 
 transformed parameters {
-  real<lower=0, upper=1> prob_eff[6];
-  real<lower=0, upper=1> prob_tox[6];
+  array[6] real<lower=0, upper=1> prob_eff;
+  array[6] real<lower=0, upper=1> prob_tox;
   prob_eff[1] = inv_logit(alpha + beta*0 + gamma*1 + zeta*0);
   prob_eff[2] = inv_logit(alpha + beta*0 + gamma*0 + zeta*1);
   prob_eff[3] = inv_logit(alpha + beta*0 + gamma*0 + zeta*0);

--- a/inst/stan/CrmEmpiricNormalPrior.stan
+++ b/inst/stan/CrmEmpiricNormalPrior.stan
@@ -17,8 +17,8 @@
 // New York: Chapman & Hall / CRC Press.
 
 functions {
-  real log_joint_pdf(int num_patients, int[] tox, int[] doses, real[] weights,
-                     real[] skeleton, real beta) {
+  real log_joint_pdf(int num_patients, array[] int tox, array[] int doses, array[] real weights,
+                     array[] real skeleton, real beta) {
     real p;
     p = 0;
     for(j in 1:num_patients) {
@@ -40,20 +40,20 @@ data {
   int<lower=1> num_doses;
   // Prior probability of toxicity at each dose, commonly referred to as the
   // skeleton. Should be monotonically increasing.
-  real<lower=0, upper = 1> skeleton[num_doses];
+  array[num_doses] real<lower=0, upper = 1> skeleton;
 
   // Observed trial outcomes
   int<lower=0> num_patients;
   // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients];
+  array[num_patients] int<lower=0, upper=1> tox;
   // Dose-levels given for patients j=1,..,num_patients.
   // Dose-levels are 1-based indices of real_doses.
   // E.g. 1 means 1st dose in real_doses was given
-  int<lower=1, upper=num_doses> doses[num_patients];
+  array[num_patients] int<lower=1, upper=num_doses> doses;
   // Weights given to observations j=1, .., num_patients.
   // Weights between 0 and 1 suggest use of TITE-CRM.
   // However, weights can take whatever real value you want.
-  real weights[num_patients];
+  array[num_patients] real weights;
 }
 
 parameters {
@@ -63,7 +63,7 @@ parameters {
 
 transformed parameters {
   // Posterior probability of toxicity at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses];
+  array[num_doses] real<lower=0, upper=1> prob_tox;
   for(i in 1:num_doses) {
     prob_tox[i] = skeleton[i] ^ exp(beta);
   }

--- a/inst/stan/CrmOneParamLogisticGammaPrior.stan
+++ b/inst/stan/CrmOneParamLogisticGammaPrior.stan
@@ -17,8 +17,8 @@
 // New York: Chapman & Hall / CRC Press.
 
 functions {
-  real log_joint_pdf(int num_patients, int[] tox, int[] doses, real[] weights,
-                     real[] codified_doses, real a0, real beta) {
+  real log_joint_pdf(int num_patients, array[] int tox, array[] int doses, array[] real weights,
+                     array[] real codified_doses, real a0, real beta) {
     real p;
     p = 0;
     for(j in 1:num_patients) {
@@ -43,22 +43,22 @@ data {
 
   // Prior probability of toxicity at each dose, commonly referred to as the
   // skeleton. Should be monotonically increasing.
-  real<lower=0, upper = 1> skeleton[num_doses];
+  array[num_doses] real<lower=0, upper = 1> skeleton;
   // Constant intercept
   real a0;
 
   // Observed trial outcomes
   int<lower=0> num_patients;
   // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients];
+  array[num_patients] int<lower=0, upper=1> tox;
   // Dose-levels given for patients j=1,..,num_patients.
   // Dose-levels are 1-based indices of real_doses.
   // E.g. 1 means 1st dose in real_doses was given.
-  int<lower=1, upper=num_doses> doses[num_patients];
+  array[num_patients] int<lower=1, upper=num_doses> doses;
   // Weights given to observations j=1, .., num_patients.
   // Weights not-equal between 0 and 1 suggest use of TITE-CRM.
   // However, weights can take whatever real value you want.
-  real weights[num_patients];
+  array[num_patients] real weights;
 }
 
 transformed data {
@@ -66,7 +66,7 @@ transformed data {
   // of skeleton values into dose-toxicity relationship. I.e. given assumed
   // dose-toxicity relationship and parameters, what "dose" gives me prob_tox =(
   // skeleton[1], skeleton[2], etc? See p.18 of Cheung (2011).
-  real codified_doses[num_doses];
+  array[num_doses] real codified_doses;
   for(i in 1:num_doses) {
     codified_doses[i] = (logit(skeleton[i]) - a0) / (beta_shape / beta_inverse_scale);
   }
@@ -79,7 +79,7 @@ parameters {
 
 transformed parameters {
   // Posterior probability of toxicity at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses];
+  array[num_doses] real<lower=0, upper=1> prob_tox;
   for(i in 1:num_doses) {
     prob_tox[i] = inv_logit(a0 + beta * codified_doses[i]);
   }

--- a/inst/stan/CrmOneParamLogisticNormalPrior.stan
+++ b/inst/stan/CrmOneParamLogisticNormalPrior.stan
@@ -17,8 +17,8 @@
 // New York: Chapman & Hall / CRC Press.
 
 functions {
-  real log_joint_pdf(int num_patients, int[] tox, int[] doses, real[] weights,
-                     real[] codified_doses, real a0, real beta) {
+  real log_joint_pdf(int num_patients, array[] int tox, array[] int doses, array[] real weights,
+                     array[] real codified_doses, real a0, real beta) {
     real p;
     p = 0;
     for(j in 1:num_patients) {
@@ -43,22 +43,22 @@ data {
 
   // Prior probability of toxicity at each dose, commonly referred to as the
   // skeleton. Should be monotonically increasing.
-  real<lower=0, upper = 1> skeleton[num_doses];
+  array[num_doses] real<lower=0, upper = 1> skeleton;
   // Constant intercept
   real a0;
 
   // Observed trial outcomes
   int<lower=0> num_patients;
   // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients];
+  array[num_patients] int<lower=0, upper=1> tox;
   // Dose-levels given for patients j=1,..,num_patients.
   // Dose-levels are 1-based indices of real_doses.
   // E.g. 1 means 1st dose in real_doses was given.
-  int<lower=1, upper=num_doses> doses[num_patients];
+  array[num_patients] int<lower=1, upper=num_doses> doses;
   // Weights given to observations j=1, .., num_patients.
   // Weights between 0 and 1 suggest use of TITE-CRM.
   // However, weights can take whatever real value you want.
-  real weights[num_patients];
+  array[num_patients] real weights;
 }
 
 transformed data {
@@ -66,7 +66,7 @@ transformed data {
   // of skeleton values into dose-toxicity relationship. I.e. given assumed
   // dose-toxicity relationship and parameters, what "dose" gives me prob_tox =
   // skeleton[1], skeleton[2], etc? See p.18 of Cheung (2011).
-  real codified_doses[num_doses];
+  array[num_doses] real codified_doses;
   for(i in 1:num_doses) {
     codified_doses[i] = (logit(skeleton[i]) - a0) / exp(beta_mean);
   }
@@ -79,7 +79,7 @@ parameters {
 
 transformed parameters {
   // Posterior probability of toxicity at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses];
+  array[num_doses] real<lower=0, upper=1> prob_tox;
   for(i in 1:num_doses) {
     prob_tox[i] = inv_logit(a0 + exp(beta) * codified_doses[i]);
   }

--- a/inst/stan/CrmTwoParamLogisticNormalPrior.stan
+++ b/inst/stan/CrmTwoParamLogisticNormalPrior.stan
@@ -22,8 +22,8 @@
 // New York: Chapman & Hall / CRC Press.
 
 functions {
-  real log_joint_pdf(int num_patients, int[] tox, int[] doses, real[] weights,
-                     real[] codified_doses, real alpha, real beta) {
+  real log_joint_pdf(int num_patients, array[] int tox, array[] int doses, array[] real weights,
+                     array[] real codified_doses, real alpha, real beta) {
     real p;
     p = 0;
     for(j in 1:num_patients) {
@@ -50,20 +50,20 @@ data {
 
   // Prior probability of toxicity at each dose, commonly referred to as the
   // skeleton. Should be monotonically increasing.
-  real<lower=0, upper = 1> skeleton[num_doses];
+  array[num_doses] real<lower=0, upper = 1> skeleton;
 
   // Observed trial outcomes
   int<lower=0> num_patients;
   // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients];
+  array[num_patients] int<lower=0, upper=1> tox;
   // Dose-levels given for patients j=1,..,num_patients.
   // Dose-levels are 1-based indices of real_doses.
   // E.g. 1 means 1st dose in real_doses was given.
-  int<lower=1, upper=num_doses> doses[num_patients];
+  array[num_patients] int<lower=1, upper=num_doses> doses;
   // Weights given to observations j=1, .., num_patients.
   // Weights between 0 and 1 suggest use of TITE-CRM.
   // However, weights can take whatever real value you want.
-  real weights[num_patients];
+  array[num_patients] real weights;
 }
 
 transformed data {
@@ -71,7 +71,7 @@ transformed data {
   // of skeleton values into dose-toxicity relationship. I.e. given assumed
   // dose-toxicity relationship and parameters, what "dose" gives me prob_tox =
   // skeleton[1], skeleton[2], etc? See p.18 of Cheung (2011).
-  real codified_doses[num_doses];
+  array[num_doses] real codified_doses;
   for(i in 1:num_doses) {
     codified_doses[i] = (logit(skeleton[i]) - alpha_mean) / exp(beta_mean);
   }
@@ -85,7 +85,7 @@ parameters {
 
 transformed parameters {
   // Posterior probability of toxicity at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses];
+  array[num_doses] real<lower=0, upper=1> prob_tox;
   for(i in 1:num_doses) {
     prob_tox[i] = inv_logit(alpha + exp(beta) * codified_doses[i]);
   }

--- a/inst/stan/EffTox.stan
+++ b/inst/stan/EffTox.stan
@@ -3,8 +3,8 @@
 //  by Thall, Herrick, Nguyen, Venier, Norris
 
 functions {
-  real log_joint_pdf(real[] coded_doses, real[] coded_doses_squ,
-                     int num_patients, int[] eff, int[] tox, int[] doses,
+  real log_joint_pdf(array[] real coded_doses, array[] real coded_doses_squ,
+                     int num_patients, array[] int eff, array[] int tox, array[] int doses,
                      real alpha, real beta, real gamma, real zeta, real eta, real psi) {
     real p;
     p = 0;
@@ -40,7 +40,7 @@ data {
   real<lower=0> psi_sd;
   // Fixed trial parameters
   int<lower=1> num_doses;
-  real<lower=0> real_doses[num_doses]; // Doses under investigation, e.g. 10, 20, 30 for 10mg, 20mg, 30mg
+  array[num_doses] real<lower=0> real_doses; // Doses under investigation, e.g. 10, 20, 30 for 10mg, 20mg, 30mg
   real p;  // The p of the L^p norm used to model the efficacy-toxicity indifference contours.
            // See Efficacy-Toxicity trade-offs based on L-p norms: Technical Report UTMDABTR-003-06
   real eff0; // Minimum required Pr(Efficacy) when Pr(Toxicity) = 0
@@ -49,17 +49,17 @@ data {
   real toxicity_hurdle; //  ... and prob(tox) is less than this hurdle
   // Observed trial outcomes
   int<lower=0> num_patients;
-  int<lower=0, upper=1> eff[num_patients]; // Binary efficacy event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients]; // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=1, upper=num_doses> doses[num_patients];  // Dose-levels given for patients j=1,..,num_patients.
+  array[num_patients] int<lower=0, upper=1> eff; // Binary efficacy event for patients j=1,..,num_patients
+  array[num_patients] int<lower=0, upper=1> tox; // Binary toxicity event for patients j=1,..,num_patients
+  array[num_patients] int<lower=1, upper=num_doses> doses;  // Dose-levels given for patients j=1,..,num_patients.
                                    // Dose-levels are 1-based indices of real_doses
                                    // E.g. 1 means 1st dose in real_doses was given
 }
 
 transformed data {
   // Thall & Cook transform the actual doses by logging and centralising:
-  real coded_doses[num_doses];
-  real coded_doses_squ[num_doses]; // The square of coded_doses
+  array[num_doses] real coded_doses;
+  array[num_doses] real coded_doses_squ; // The square of coded_doses
   real mean_log_dose; // Variable created for convenience
   mean_log_dose = 0.0;
   for(i in 1:num_doses)
@@ -86,9 +86,9 @@ parameters {
 }
 
 transformed parameters {
-  real<lower=0, upper=1> prob_eff[num_doses]; // Posterior probability of efficacy at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses]; // Posterior probability of toxicity at doses i=1,...,num_doses
-  real utility[num_doses]; // Posterior utility of doses i=1,...,num_doses
+  array[num_doses] real<lower=0, upper=1> prob_eff; // Posterior probability of efficacy at doses i=1,...,num_doses
+  array[num_doses] real<lower=0, upper=1> prob_tox; // Posterior probability of toxicity at doses i=1,...,num_doses
+  array[num_doses] real utility; // Posterior utility of doses i=1,...,num_doses
   // Calculate the utility of each dose using the method described in
   // "Efficacy-Toxicity trade-offs based on L-p norms: Technical Report UTMDABTR-003-06", John Cook
   for(i in 1:num_doses)

--- a/inst/stan/NeuenschwanderTwoParamLogit.stan
+++ b/inst/stan/NeuenschwanderTwoParamLogit.stan
@@ -23,8 +23,8 @@
 // Statistics in Medicine, 27, 2420–2439. https://doi.org/10.1002/sim
 
 functions {
-  real log_joint_pdf(int num_patients, int[] tox, real[] codified_doses,
-                     real[] weights, real alpha, real beta) {
+  real log_joint_pdf(int num_patients, array[] int tox, array[] real codified_doses,
+                     array[] real weights, real alpha, real beta) {
     real p;
     p = 0;
     for(j in 1:num_patients) {
@@ -50,27 +50,27 @@ data {
   int<lower=1> num_doses;
 
   // Doses under investigation, e.g. 10, 20, 30 for 10mg, 20mg, 30mg:
-  real<lower=0> real_doses[num_doses];
+  array[num_doses] real<lower=0> real_doses;
   // Reference dose
   real<lower=0> d_star;
 
   // Observed trial outcomes
   int<lower=0> num_patients;
   // Binary toxicity event for patients j=1,..,num_patients
-  int<lower=0, upper=1> tox[num_patients];
+  array[num_patients] int<lower=0, upper=1> tox;
   // Dose-levels given for patients j=1,..,num_patients.
   // Dose-levels are 1-based indices of real_doses.
   // E.g. 1 means 1st dose in real_doses was given.
-  int<lower=1, upper=num_doses> doses[num_patients];
+  array[num_patients] int<lower=1, upper=num_doses> doses;
   // Weights given to observations j=1, .., num_patients.
   // Weights between 0 and 1 suggest use of TITE-CRM.
   // However, weights can take whatever real value you want.
-  real weights[num_patients];
+  array[num_patients] real weights;
 }
 
 transformed data {
   // Codified doses in this model are simply doses given over the reference dose
-  real codified_doses[num_patients];
+  array[num_patients] real codified_doses;
   for(j in 1:num_patients) {
     codified_doses[j] = log(real_doses[doses[j]] / d_star);
   }
@@ -84,7 +84,7 @@ parameters {
 
 transformed parameters {
   // Posterior probability of toxicity at doses i=1,...,num_doses
-  real<lower=0, upper=1> prob_tox[num_doses];
+  array[num_doses] real<lower=0, upper=1> prob_tox;
   for(i in 1:num_doses) {
     prob_tox[i] = inv_logit(alpha + exp(beta) * log(real_doses[i] / d_star));
   }

--- a/inst/stan/ThallHierarchicalBinary.stan
+++ b/inst/stan/ThallHierarchicalBinary.stan
@@ -8,8 +8,8 @@
 data {
   // Observed data and trial constants
   int<lower=1> num_groups;                   // Number of cohorts
-  int<lower=0> group_responses[num_groups];  // Number of responses by cohort
-  int<lower=0> group_sizes[num_groups];      // Number of patients by cohort
+  array[num_groups] int<lower=0> group_responses;  // Number of responses by cohort
+  array[num_groups] int<lower=0> group_sizes;      // Number of patients by cohort
 
   // Hyperparameters for mu
   real mu_mean;
@@ -23,12 +23,12 @@ data {
 parameters {
   real mu;                // Mean of the groupwise log-odds of response
   real<lower=0.0> sigma2;  // Variance of the groupwise log-odds of response
-  real rho[num_groups];   // Log-odds of response by cohort
+  array[num_groups] real rho;   // Log-odds of response by cohort
 }
 
 transformed parameters {
   real<lower=0.0> sigma;
-  real<lower=0.0, upper=1.0> prob_response[num_groups]; // Probability of response by cohort
+  array[num_groups] real<lower=0.0, upper=1.0> prob_response; // Probability of response by cohort
   sigma = sqrt(sigma2);
   for (i in 1:num_groups)
   {

--- a/man/as.mcmc.list.crm_fit.Rd
+++ b/man/as.mcmc.list.crm_fit.Rd
@@ -5,10 +5,10 @@
 \title{Convert \code{\link{crm_fit}} to instance of
 \code{\link[coda]{mcmc.list}}}
 \usage{
-\method{as.mcmc.list}{crm_fit}(crm_fit, ...)
+\method{as.mcmc.list}{crm_fit}(x, ...)
 }
 \arguments{
-\item{crm_fit}{Object of class \code{\link{crm_fit}}}
+\item{x}{Object of class \code{\link{crm_fit}}}
 
 \item{...}{Extra variables that are passed onwards.}
 }

--- a/man/as.mcmc.list.efftox_fit.Rd
+++ b/man/as.mcmc.list.efftox_fit.Rd
@@ -5,10 +5,10 @@
 \title{Convert \code{\link{efftox_fit}} to instance of
 \code{\link[coda]{mcmc.list}}}
 \usage{
-\method{as.mcmc.list}{efftox_fit}(efftox_fit, ...)
+\method{as.mcmc.list}{efftox_fit}(x, ...)
 }
 \arguments{
-\item{efftox_fit}{Object of class \code{\link{efftox_fit}}}
+\item{x}{Object of class \code{\link{efftox_fit}}}
 
 \item{...}{Extra variables that are passed onwards.}
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
